### PR TITLE
add a manual set device info method, so theres no need to run discove…

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -17,6 +17,13 @@
             "accessory": "broadlinkSP",
             "name": "My Broadlink SP2",
             "mac": "34:ea:34:e4:00:22"
+        },
+        {
+            "accessory": "broadlinkSP",
+            "name": "My Broadlink SP2 (device type 0x2711) - without discover",
+            "mac": "34:ea:34:e4:00:23",
+            "ip": "192.168.1.13",
+            "devtype": 10001
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-broadlink-sp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Homebridge plugin for Broadlink SP2/3",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
add a manual set device info method, so theres no need to run discover everytime before getting / setting state, avoid this plugin freezes homebridge service; bump version to 0.1.4

this could also partial fix #5 in some network conditions.